### PR TITLE
Install C++ headers and shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime-green.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--cpp-green.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--novec-green.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--novec--cpp-green.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) |
 
 Installing onnxruntime
 ======================
@@ -262,16 +264,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `onnxruntime, onnxruntime-novec` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `onnxruntime, onnxruntime-cpp, onnxruntime-novec, onnxruntime-novec-cpp` can be installed with `conda`:
 
 ```
-conda install onnxruntime onnxruntime-novec
+conda install onnxruntime onnxruntime-cpp onnxruntime-novec onnxruntime-novec-cpp
 ```
 
 or with `mamba`:
 
 ```
-mamba install onnxruntime onnxruntime-novec
+mamba install onnxruntime onnxruntime-cpp onnxruntime-novec onnxruntime-novec-cpp
 ```
 
 It is possible to list all of the versions of `onnxruntime` available on your platform with `conda`:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,7 @@ cmake_extra_defines=( "Protobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc" \
                       "onnxruntime_PREFER_SYSTEM_LIB=ON" \
                       "onnxruntime_USE_COREML=OFF" \
                       "onnxruntime_DONT_VECTORIZE=$DONT_VECTORIZE" \
+                      "onnxruntime_BUILD_SHARED_LIB=ON" \
                       "CMAKE_PREFIX_PATH=$PREFIX" )
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)
@@ -59,3 +60,11 @@ python tools/ci_build/build.py \
 
 cp build-ci/Release/dist/onnxruntime-*.whl onnxruntime-${PKG_VERSION}-py3-none-any.whl
 python -m pip install onnxruntime-${PKG_VERSION}-py3-none-any.whl
+mkdir -p "${PREFIX}/include"
+cp -pr include/onnxruntime "${PREFIX}/include/"
+
+if [[ -n "${OSX_ARCH}" ]]; then
+    install build-ci/Release/libonnxruntime.*dylib "${PREFIX}/lib"
+else
+    install build-ci/Release/libonnxruntime.so* "${PREFIX}/lib"
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -60,11 +60,3 @@ python tools/ci_build/build.py \
 
 cp build-ci/Release/dist/onnxruntime-*.whl onnxruntime-${PKG_VERSION}-py3-none-any.whl
 python -m pip install onnxruntime-${PKG_VERSION}-py3-none-any.whl
-mkdir -p "${PREFIX}/include"
-cp -pr include/onnxruntime "${PREFIX}/include/"
-
-if [[ -n "${OSX_ARCH:+yes}" ]]; then
-    install build-ci/Release/libonnxruntime.*dylib "${PREFIX}/lib"
-else
-    install build-ci/Release/libonnxruntime.so* "${PREFIX}/lib"
-fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,7 +63,7 @@ python -m pip install onnxruntime-${PKG_VERSION}-py3-none-any.whl
 mkdir -p "${PREFIX}/include"
 cp -pr include/onnxruntime "${PREFIX}/include/"
 
-if [[ -n "${OSX_ARCH}" ]]; then
+if [[ -n "${OSX_ARCH:+yes}" ]]; then
     install build-ci/Release/libonnxruntime.*dylib "${PREFIX}/lib"
 else
     install build-ci/Release/libonnxruntime.so* "${PREFIX}/lib"

--- a/recipe/install-cpp.sh
+++ b/recipe/install-cpp.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+mkdir -p "${PREFIX}/include"
+mkdir -p "${PREFIX}/lib"
+cp -pr include/onnxruntime "${PREFIX}/include/"
+
+if [[ -n "${OSX_ARCH:+yes}" ]]; then
+    install build-ci/Release/libonnxruntime.*dylib "${PREFIX}/lib"
+else
+    install build-ci/Release/libonnxruntime.so* "${PREFIX}/lib"
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,24 @@ test:
   requires:
     - pip
 
+outputs:
+  - name: {{ name|lower }}{{ suffix }}
+  - name: {{ name|lower }}{{ suffix }}-cpp
+    script: install-cpp.sh
+    requirements:
+      run:
+        - protobuf
+        - {{ pin_compatible('re2') }}
+    test:
+      requires:
+        - {{ compiler('cxx') }}
+      files:
+        - test.cpp
+      commands:
+        - $CXX $CXXFLAGS -I$PREFIX/include/ -L$PREFIX/lib/ -lonnxruntime test.cpp                               # [linux]
+        - $CXX $CXXFLAGS -I$PREFIX/include/ -L$PREFIX/lib/ -lonnxruntime -Wl,-rpath,$CONDA_PREFIX/lib test.cpp  # [osx]
+        - ./a.out
+
 about:
   home: https://github.com/microsoft/onnxruntime/
   summary: cross-platform, high performance ML inferencing and training accelerator

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     sha256: 5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4
     folder: json
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   # Since 1.11, power9 seems to be required.
   skip: true  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,6 +89,8 @@ outputs:
       run:
         - protobuf
         - {{ pin_compatible('re2') }}
+      run_constrained:
+        - onnxruntime-cpp <0a0  # [suffix == "-novec"]
     test:
       requires:
         - {{ compiler('cxx') }}

--- a/recipe/test.cpp
+++ b/recipe/test.cpp
@@ -1,0 +1,16 @@
+#define ORT_API_MANUAL_INIT
+#include <onnxruntime/core/session/onnxruntime_cxx_api.h>
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    Ort::InitApi();
+    const auto providers = Ort::GetAvailableProviders();
+
+    for (const auto& provider : providers) {
+        std::cout << provider << '\n';
+    }
+
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
Hello,

This patch just enables and install the C++ headers and shared libraries, so onnxruntime can be also be used from C++ applications like sourcextractor++ (which is not yet part of conda-forge, but may be one day)

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
