### PR TITLE
Add variant that compiles with EIGEN_DONT_VECTORIZE

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,36 +8,68 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.19python3.7.____cpython:
-        CONFIG: linux_64_numpy1.19python3.7.____cpython
+      linux_64_numpy1.19python3.7.____cpythonsuffix:
+        CONFIG: linux_64_numpy1.19python3.7.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.19python3.8.____cpython:
-        CONFIG: linux_64_numpy1.19python3.8.____cpython
+      linux_64_numpy1.19python3.7.____cpythonsuffix-novec:
+        CONFIG: linux_64_numpy1.19python3.7.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.19python3.9.____cpython:
-        CONFIG: linux_64_numpy1.19python3.9.____cpython
+      linux_64_numpy1.19python3.8.____cpythonsuffix:
+        CONFIG: linux_64_numpy1.19python3.8.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.21python3.10.____cpython:
-        CONFIG: linux_64_numpy1.21python3.10.____cpython
+      linux_64_numpy1.19python3.8.____cpythonsuffix-novec:
+        CONFIG: linux_64_numpy1.19python3.8.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.19python3.7.____cpython:
-        CONFIG: linux_aarch64_numpy1.19python3.7.____cpython
+      linux_64_numpy1.19python3.9.____cpythonsuffix:
+        CONFIG: linux_64_numpy1.19python3.9.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.19python3.8.____cpython:
-        CONFIG: linux_aarch64_numpy1.19python3.8.____cpython
+      linux_64_numpy1.19python3.9.____cpythonsuffix-novec:
+        CONFIG: linux_64_numpy1.19python3.9.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.19python3.9.____cpython:
-        CONFIG: linux_aarch64_numpy1.19python3.9.____cpython
+      linux_64_numpy1.21python3.10.____cpythonsuffix:
+        CONFIG: linux_64_numpy1.21python3.10.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.21python3.10.____cpython:
-        CONFIG: linux_aarch64_numpy1.21python3.10.____cpython
+      linux_64_numpy1.21python3.10.____cpythonsuffix-novec:
+        CONFIG: linux_64_numpy1.21python3.10.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.7.____cpythonsuffix:
+        CONFIG: linux_aarch64_numpy1.19python3.7.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec:
+        CONFIG: linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.8.____cpythonsuffix:
+        CONFIG: linux_aarch64_numpy1.19python3.8.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec:
+        CONFIG: linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.9.____cpythonsuffix:
+        CONFIG: linux_aarch64_numpy1.19python3.9.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec:
+        CONFIG: linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.21python3.10.____cpythonsuffix:
+        CONFIG: linux_aarch64_numpy1.21python3.10.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec:
+        CONFIG: linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,26 +8,47 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.19python3.7.____cpython:
-        CONFIG: osx_64_numpy1.19python3.7.____cpython
+      osx_64_numpy1.19python3.7.____cpythonsuffix:
+        CONFIG: osx_64_numpy1.19python3.7.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.19python3.8.____cpython:
-        CONFIG: osx_64_numpy1.19python3.8.____cpython
+      osx_64_numpy1.19python3.7.____cpythonsuffix-novec:
+        CONFIG: osx_64_numpy1.19python3.7.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.19python3.9.____cpython:
-        CONFIG: osx_64_numpy1.19python3.9.____cpython
+      osx_64_numpy1.19python3.8.____cpythonsuffix:
+        CONFIG: osx_64_numpy1.19python3.8.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.21python3.10.____cpython:
-        CONFIG: osx_64_numpy1.21python3.10.____cpython
+      osx_64_numpy1.19python3.8.____cpythonsuffix-novec:
+        CONFIG: osx_64_numpy1.19python3.8.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.19python3.8.____cpython:
-        CONFIG: osx_arm64_numpy1.19python3.8.____cpython
+      osx_64_numpy1.19python3.9.____cpythonsuffix:
+        CONFIG: osx_64_numpy1.19python3.9.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.19python3.9.____cpython:
-        CONFIG: osx_arm64_numpy1.19python3.9.____cpython
+      osx_64_numpy1.19python3.9.____cpythonsuffix-novec:
+        CONFIG: osx_64_numpy1.19python3.9.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.21python3.10.____cpython:
-        CONFIG: osx_arm64_numpy1.21python3.10.____cpython
+      osx_64_numpy1.21python3.10.____cpythonsuffix:
+        CONFIG: osx_64_numpy1.21python3.10.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.21python3.10.____cpythonsuffix-novec:
+        CONFIG: osx_64_numpy1.21python3.10.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.19python3.8.____cpythonsuffix:
+        CONFIG: osx_arm64_numpy1.19python3.8.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec:
+        CONFIG: osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.19python3.9.____cpythonsuffix:
+        CONFIG: osx_arm64_numpy1.19python3.9.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec:
+        CONFIG: osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.21python3.10.____cpythonsuffix:
+        CONFIG: osx_arm64_numpy1.21python3.10.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec:
+        CONFIG: osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- -novec
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.19python3.7.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
@@ -17,15 +17,17 @@ docker_image:
 libprotobuf:
 - '3.19'
 numpy:
-- '1.21'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.8.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.19python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.8.____cpythonsuffix.yaml
@@ -1,23 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
 - '3.19'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -28,8 +26,10 @@ python:
 - 3.8.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- ''
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -27,11 +23,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
@@ -17,15 +17,17 @@ docker_image:
 libprotobuf:
 - '3.19'
 numpy:
-- '1.19'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
@@ -1,23 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
 - '3.19'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -28,8 +30,10 @@ python:
 - 3.7.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19python3.7.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.7.____cpythonsuffix.yaml
@@ -1,21 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
 - '3.19'
-macos_machine:
-- arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -23,11 +27,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- ''
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
@@ -1,9 +1,13 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -23,11 +27,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.8.____cpythonsuffix.yaml
@@ -27,9 +27,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- ''
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
@@ -1,0 +1,41 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- -novec
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpythonsuffix.yaml
@@ -1,23 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
 - '3.19'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -28,8 +30,10 @@ python:
 - 3.9.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- ''
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
@@ -30,6 +30,8 @@ python:
 - 3.10.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonsuffix.yaml
@@ -1,0 +1,41 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____cpythonsuffix-novec.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 c_compiler:
 - clang
 c_compiler_version:
@@ -15,7 +17,7 @@ cxx_compiler_version:
 libprotobuf:
 - '3.19'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -23,11 +25,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.19python3.7.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____cpythonsuffix.yaml
@@ -19,15 +19,17 @@ libprotobuf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.7.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- ''
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- -novec
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.19python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.8.____cpythonsuffix.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 c_compiler:
 - clang
 c_compiler_version:
@@ -15,19 +17,21 @@ cxx_compiler_version:
 libprotobuf:
 - '3.19'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpythonsuffix.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
@@ -1,33 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '13'
 libprotobuf:
 - '3.19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpythonsuffix.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec.yaml
@@ -1,25 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '13'
 libprotobuf:
 - '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -27,11 +23,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 re2:
 - 2022.06.01
+suffix:
+- -novec
 target_platform:
-- linux-aarch64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_numpy1.19python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.8.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- -novec
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.19python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy1.19python3.9.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- -novec
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpythonsuffix.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+libprotobuf:
+- '3.19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+re2:
+- 2022.06.01
+suffix:
+- ''
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -48,6 +51,10 @@ fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -61,6 +61,10 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
 fi
 
 
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -27,108 +27,213 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.19python3.7.____cpython</td>
+              <td>linux_64_numpy1.19python3.7.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.7.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.19python3.8.____cpython</td>
+              <td>linux_64_numpy1.19python3.7.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.7.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.19python3.9.____cpython</td>
+              <td>linux_64_numpy1.19python3.8.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.8.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.10.____cpython</td>
+              <td>linux_64_numpy1.19python3.8.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.8.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.19python3.7.____cpython</td>
+              <td>linux_64_numpy1.19python3.9.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.9.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.19python3.8.____cpython</td>
+              <td>linux_64_numpy1.19python3.9.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.9.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.19python3.9.____cpython</td>
+              <td>linux_64_numpy1.21python3.10.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.21python3.10.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.10.____cpython</td>
+              <td>linux_64_numpy1.21python3.10.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.21python3.10.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.7.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.7.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.8.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.8.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.8.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.10.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.8.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.19python3.8.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.9.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpythonsuffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.19python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.21python3.10.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.10.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.21python3.10.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.21python3.10.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.7.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.7.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.7.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.7.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.8.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.8.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.8.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.8.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.9.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.9.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.21python3.10.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.21python3.10.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.21python3.10.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.21python3.10.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.19python3.8.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.8.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.8.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.19python3.9.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.9.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.19python3.9.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.21python3.10.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.21python3.10.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.21python3.10.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
             </tr>
@@ -145,6 +250,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime-green.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--novec-green.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) |
 
 Installing onnxruntime
 ======================
@@ -156,16 +262,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `onnxruntime` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `onnxruntime, onnxruntime-novec` can be installed with `conda`:
 
 ```
-conda install onnxruntime
+conda install onnxruntime onnxruntime-novec
 ```
 
 or with `mamba`:
 
 ```
-mamba install onnxruntime
+mamba install onnxruntime onnxruntime-novec
 ```
 
 It is possible to list all of the versions of `onnxruntime` available on your platform with `conda`:

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/0001_dont_vectorize.patch
+++ b/recipe/0001_dont_vectorize.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index 28e7d2aa9..cf3a4ed2a 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -80,6 +80,7 @@ option(onnxruntime_TENSORRT_PLACEHOLDER_BUILDER "Instantiate Placeholder TensorR
+ option(onnxruntime_ENABLE_LTO "Enable link time optimization" OFF)
+ option(onnxruntime_CROSS_COMPILING "Cross compiling onnx runtime" OFF)
+ option(onnxruntime_GCOV_COVERAGE "Compile with options necessary to run code coverage" OFF)
++option(onnxruntime_DONT_VECTORIZE "Do not vectorize operations in Eigen" OFF)
+ 
+ #It's preferred to turn it OFF when onnxruntime is dynamically linked to PROTOBUF. But Tensort always required the full version of protobuf.
+ cmake_dependent_option(onnxruntime_USE_FULL_PROTOBUF "Link to libprotobuf instead of libprotobuf-lite when this option is ON" OFF "NOT onnxruntime_USE_TENSORRT" ON)
+@@ -487,6 +488,10 @@ if (MSVC)
+           -DEIGEN_STRONG_INLINE=inline)
+ endif()
+ 
++if ( onnxruntime_DONT_VECTORIZE )
++  add_definitions(-DEIGEN_DONT_VECTORIZE=1)
++endif()
++
+ if (onnxruntime_CROSS_COMPILING)
+   set(CMAKE_CROSSCOMPILING ON)
+   check_cxx_compiler_flag(-Wno-error HAS_NOERROR)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,6 +24,7 @@ cmake_extra_defines=( "Protobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc" \
                       "Protobuf_INCLUDE_DIR=$PREFIX/include" \
                       "onnxruntime_PREFER_SYSTEM_LIB=ON" \
                       "onnxruntime_USE_COREML=OFF" \
+                      "onnxruntime_DONT_VECTORIZE=$DONT_VECTORIZE" \
                       "CMAKE_PREFIX_PATH=$PREFIX" )
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,12 @@ pushd "${external_root}/SafeInt/safeint"
 ln -s $PREFIX/include/SafeInt.hpp
 popd
 
+if [[ "${PKG_NAME}" == 'onnxruntime-novec' ]]; then
+    DONT_VECTORIZE="ON"
+else
+    DONT_VECTORIZE="OFF"
+fi
+
 cmake_extra_defines=( "Protobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc" \
                       "Protobuf_INCLUDE_DIR=$PREFIX/include" \
                       "onnxruntime_PREFER_SYSTEM_LIB=ON" \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 MACOSX_SDK_VERSION:        # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
+suffix:
+  - ""
+  - "-novec"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}{{ suffix }}
   version: {{ version }}
 
 source:
@@ -28,8 +28,6 @@ build:
   skip: true  # [win]
   # Since 1.11, power9 seems to be required.
   skip: true  # [ppc64le]
-  script_env:
-    - DONT_VECTORIZE=ON
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,8 @@ requirements:
     - python-flatbuffers
     - {{ pin_compatible('numpy') }}
     - protobuf
+  run_constrained:
+    - onnxruntime <0a0  # [suffix == "-no-vec"]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - protobuf
   run_constrained:
-    - onnxruntime <0a0  # [suffix == "-no-vec"]
+    - onnxruntime <0a0  # [suffix == "-novec"]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   - url: https://github.com/microsoft/onnxruntime/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 307ba492dc6a35992ca561fa1c90ad919ed6bd40adef578a07725b5e88ccf633
+    patches:
+      - 0001_dont_vectorize.patch
   - url: https://github.com/onnx/onnx/archive/850a81b0b77786bf99ea90580242b084f86a6235.tar.gz
     sha256: 3b09259ec93b2b1d33e7321977038c4fd73eaac9fd0632765978f896da905f3f
     folder: onnx
@@ -22,10 +24,12 @@ source:
     sha256: 4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b
     folder: json
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   # Since 1.11, power9 seems to be required.
   skip: true  # [ppc64le]
+  script_env:
+    - DONT_VECTORIZE=ON
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds an additional output `onnxruntime-novec` that builds the ONNX runtime with the flag `-DEIGEN_DONT_VECTORIZE`.

See 
- https://github.com/microsoft/onnxruntime/issues/10058
- https://gitlab.com/libeigen/eigen/-/issues/2413

for context.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
