### PR TITLE
Add support for CUDA builds on Windows (1.18.0 version)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -208,7 +208,7 @@ jobs:
       : CONFIG: linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-    maxParallel: 31
+    maxParallel: 25
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -68,7 +68,7 @@ jobs:
       osx_arm64_numpy2.0python3.9.____cpythonsuffix-novec:
         CONFIG: osx_arm64_numpy2.0python3.9.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 12
+    maxParallel: 10
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -101,7 +101,7 @@ jobs:
     maxParallel: 15
   timeoutInMinutes: 360
   variables:
-    CONDA_BLD_PATH: D:\\bld\\
+    CONDA_BLD_PATH: C:\bld\
     SET_PAGEFILE: 'True'
     UPLOAD_TEMP: D:\\tmp
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -38,7 +38,67 @@ jobs:
       win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec:
         CONFIG: win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 6
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec
+        UPLOAD_PACKAGES: 'True'
+    maxParallel: 15
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix.yaml
@@ -10,6 +10,8 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cudnn:
+- '8'
 cxx_compiler:
 - vs2022
 numpy:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -7,9 +7,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
@@ -23,7 +23,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix.yaml
@@ -7,9 +7,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -7,9 +7,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
@@ -23,7 +23,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix.yaml
@@ -7,9 +7,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -7,23 +7,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cudnn:
 - '8'
 cxx_compiler:
 - vs2022
 numpy:
-- '1.22'
+- '2.0'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 suffix:
 - ''
 target_platform:

--- a/README.md
+++ b/README.md
@@ -608,6 +608,146 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,6 +5,7 @@ azure:
   settings_win:
     variables:
       SET_PAGEFILE: 'True'
+      CONDA_BLD_PATH: C:\bld\
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,8 +3,16 @@
 :: Enable CUDA support
 if "%cuda_compiler_version%"=="None" (
     set "BUILD_ARGS="
+    set onnxruntime_BUILD_UNIT_TESTS=ON
 ) else (
-    set "BUILD_ARGS=--use_cuda --cudnn_home %PREFIX%\Library"
+    set "BUILD_ARGS=--use_cuda  --cuda_home %LIBRARY_PREFIX% --cudnn_home %LIBRARY_PREFIX%"
+    set onnxruntime_BUILD_UNIT_TESTS=OFF
+)
+
+if "%cuda_compiler_version%"=="11.8" (
+    set "CMAKE_CUDA_ARCHITECTURES=all-major"
+) else (
+    set "CMAKE_CUDA_ARCHITECTURES=all"
 )
 
 :: We set CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON as currently we do not want to use
@@ -12,7 +20,7 @@ if "%cuda_compiler_version%"=="None" (
 python tools/ci_build/build.py ^
     --compile_no_warning_as_error ^
     --build_dir build-ci ^
-    --cmake_extra_defines EIGEN_MPL2_ONLY=ON "onnxruntime_USE_COREML=OFF" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=ON" CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON CMAKE_CUDA_ARCHITECTURES=all ^
+    --cmake_extra_defines EIGEN_MPL2_ONLY=ON "onnxruntime_USE_COREML=OFF" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=%onnxruntime_BUILD_UNIT_TESTS%" CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON CMAKE_CUDA_ARCHITECTURES=%CMAKE_CUDA_ARCHITECTURES% ^
     --cmake_generator Ninja ^
     --build_wheel ^
     --config Release ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,18 +9,12 @@ if "%cuda_compiler_version%"=="None" (
     set onnxruntime_BUILD_UNIT_TESTS=OFF
 )
 
-if "%cuda_compiler_version%"=="11.8" (
-    set "CMAKE_CUDA_ARCHITECTURES=all-major"
-) else (
-    set "CMAKE_CUDA_ARCHITECTURES=all"
-)
-
 :: We set CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON as currently we do not want to use
 :: protobuf from conda-forge, see https://github.com/conda-forge/onnxruntime-feedstock/issues/57#issuecomment-1518033552
 python tools/ci_build/build.py ^
     --compile_no_warning_as_error ^
     --build_dir build-ci ^
-    --cmake_extra_defines EIGEN_MPL2_ONLY=ON "onnxruntime_USE_COREML=OFF" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=%onnxruntime_BUILD_UNIT_TESTS%" CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON CMAKE_CUDA_ARCHITECTURES=%CMAKE_CUDA_ARCHITECTURES% ^
+    --cmake_extra_defines EIGEN_MPL2_ONLY=ON "onnxruntime_USE_COREML=OFF" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=%onnxruntime_BUILD_UNIT_TESTS%" CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% CMAKE_DISABLE_FIND_PACKAGE_Protobuf=ON CMAKE_CUDA_ARCHITECTURES=all-major ^
     --cmake_generator Ninja ^
     --build_wheel ^
     --config Release ^

--- a/recipe/do_not_pass_msvc_style_definitions_to_nvcc.patch
+++ b/recipe/do_not_pass_msvc_style_definitions_to_nvcc.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/ci_build/build.py b/tools/ci_build/build.py
+index 85583e1..22b91fa 100644
+--- a/tools/ci_build/build.py
++++ b/tools/ci_build/build.py
+@@ -1525,7 +1525,7 @@ def generate_build_tree(
+                     cuda_compile_flags_str = ""
+                     for compile_flag in cflags:
+                         if compile_flag.startswith("/D"):
+-                            cudaflags.append(compile_flag)
++                            cudaflags.append(compile_flag.replace("/D","-D"))
+                         else:
+                             cuda_compile_flags_str = cuda_compile_flags_str + " " + compile_flag
+                     if len(cuda_compile_flags_str) != 0:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,6 +106,11 @@ test:
     - onnxruntime_test --help
   requires:
     - pip
+    # 2024/05 hmaarrfk/jtilly
+    # Test the pip check command with numpy < 2
+    # which was included in the requirements file for
+    # build time compatibility
+    - numpy 1.26   # [py == 312]
 
 outputs:
   - name: {{ name|lower }}{{ suffix }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,7 @@ test:
     # Test the pip check command with numpy < 2
     # which was included in the requirements file for
     # build time compatibility
-    - numpy 1.26   # [py == 312]
+    - numpy 1.26.*   # [py == 312]
 
 outputs:
   - name: {{ name|lower }}{{ suffix }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ source:
       - cxx_17_for_darwin.patch
       # Workaround for https://github.com/conda-forge/onnxruntime-feedstock/pull/115#issuecomment-2122077816
       - do_not_pass_msvc_style_definitions_to_nvcc.patch  # [win]
+      - remove_numpy_version.patch
+
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
 {% set version = "1.18.0" %}
 {% set suffix = "" %}  # [suffix == None]
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_enabled %}
 {% set build = build + 200 %}
@@ -28,14 +28,13 @@ source:
       # Workaround for https://github.com/conda-forge/onnxruntime-feedstock/pull/56#issuecomment-1586080419
       - windows_workaround_conflict_onnxruntime_dll_system32.patch  # [win]
       - cxx_17_for_darwin.patch
-
+      # Workaround for https://github.com/conda-forge/onnxruntime-feedstock/pull/115#issuecomment-2122077816
+      - do_not_pass_msvc_style_definitions_to_nvcc.patch  # [win]
 
 build:
   number: {{ build }}
   # Since 1.11, power9 seems to be required.
   skip: true  # [ppc64le]
-  # CUDA compilation for Windows goes out-of-memory.
-  skip: true  # [win and cuda_compiler_version in ("11.2", "11.8", "12.0")]
   skip: true  # [linux and aarch64 and cuda_compiler_version == "12.0"]
   skip: true  # [cuda_compiler_version == "11.2"]
   string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}

--- a/recipe/remove_numpy_version.patch
+++ b/recipe/remove_numpy_version.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements.txt.in b/requirements.txt.in
+index 89242061fb..a9c1327b8f 100644
+--- a/requirements.txt.in
++++ b/requirements.txt.in
+@@ -1,6 +1,6 @@
+ coloredlogs
+ flatbuffers
+-numpy >= @Python_NumPy_VERSION@
++numpy
+ packaging
+ protobuf
+ sympy


### PR DESCRIPTION
Fix https://github.com/conda-forge/onnxruntime-feedstock/issues/99 .

Follow up of https://github.com/conda-forge/onnxruntime-feedstock/pull/115 . Mostly just adds options for cuda 12, switch `CMAKE_CUDA_ARCHITECTURES` from `all` to `all-major` (as done in Linux) and add a patch for cuda build.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
