### PR TITLE
Remove NumPy version from pip requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,6 +106,11 @@ test:
     - onnxruntime_test --help
   requires:
     - pip
+    # 2024/05 hmaarrfk/jtilly
+    # Test the pip check command with numpy < 2
+    # which was included in the requirements file for
+    # build time compatibility
+    - numpy 1.26   # [py == 312]
 
 outputs:
   - name: {{ name|lower }}{{ suffix }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
 {% set version = "1.18.0" %}
 {% set suffix = "" %}  # [suffix == None]
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_enabled %}
 {% set build = build + 200 %}
@@ -28,6 +28,7 @@ source:
       # Workaround for https://github.com/conda-forge/onnxruntime-feedstock/pull/56#issuecomment-1586080419
       - windows_workaround_conflict_onnxruntime_dll_system32.patch  # [win]
       - cxx_17_for_darwin.patch
+      - remove_numpy_version.patch
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,7 @@ test:
     # Test the pip check command with numpy < 2
     # which was included in the requirements file for
     # build time compatibility
-    - numpy 1.26   # [py == 312]
+    - numpy 1.26.*   # [py == 312]
 
 outputs:
   - name: {{ name|lower }}{{ suffix }}

--- a/recipe/remove_numpy_version.patch
+++ b/recipe/remove_numpy_version.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements.txt.in b/requirements.txt.in
+index 89242061fb..a9c1327b8f 100644
+--- a/requirements.txt.in
++++ b/requirements.txt.in
+@@ -1,6 +1,6 @@
+ coloredlogs
+ flatbuffers
+-numpy >= @Python_NumPy_VERSION@
++numpy
+ packaging
+ protobuf
+ sympy


### PR DESCRIPTION
Closes #122 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm patching the NumPy version in the pip requirements so that we don't end up with (incorrect) errors when we run `pip check`.