### PR TITLE
Respect suffix for package name

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.17cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -47,4 +47,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.8.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.10.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.11.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.12.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy2.0python3.9.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.22python3.8.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.10.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.11.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.12.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy2.0python3.9.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -51,4 +51,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.10.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.11.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.12.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.9.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.15'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.10.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.11.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.12.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.9.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -42,4 +42,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.8.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy2.0python3.9.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy1.22python3.8.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0numpy2.0python3.9.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy1.22python3.8.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8numpy2.0python3.9.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge/label/numpy_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -32,4 +32,4 @@ zip_keys:
 - - python
   - numpy
 zlib:
-- '1.2'
+- '1'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,6 +72,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -85,6 +85,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -59,6 +59,11 @@ set "CONDA_SOLVER=libmamba"
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ Package license: MIT AND BSL-1.0
 
 Summary: cross-platform, high performance ML inferencing and training accelerator
 
+About onnxruntime-novec
+-----------------------
+
+Home: https://github.com/microsoft/onnxruntime/
+
+Package license: MIT AND BSL-1.0
+
+Summary: cross-platform, high performance ML inferencing and training accelerator
+
+About onnxruntime-novec-cpp
+---------------------------
+
+Home: https://github.com/microsoft/onnxruntime/
+
+Package license: MIT AND BSL-1.0
+
+Summary: cross-platform, high performance ML inferencing and training accelerator
+
 Current build status
 ====================
 
@@ -763,6 +781,8 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime-green.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime.svg)](https://anaconda.org/conda-forge/onnxruntime) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--cpp-green.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-cpp) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--novec-green.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-novec.svg)](https://anaconda.org/conda-forge/onnxruntime-novec) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onnxruntime--novec--cpp-green.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onnxruntime-novec-cpp.svg)](https://anaconda.org/conda-forge/onnxruntime-novec-cpp) |
 
 Installing onnxruntime
 ======================
@@ -774,16 +794,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `onnxruntime, onnxruntime-cpp` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `onnxruntime, onnxruntime-cpp, onnxruntime-novec, onnxruntime-novec-cpp` can be installed with `conda`:
 
 ```
-conda install onnxruntime onnxruntime-cpp
+conda install onnxruntime onnxruntime-cpp onnxruntime-novec onnxruntime-novec-cpp
 ```
 
 or with `mamba`:
 
 ```
-mamba install onnxruntime onnxruntime-cpp
+mamba install onnxruntime onnxruntime-cpp onnxruntime-novec onnxruntime-novec-cpp
 ```
 
 It is possible to list all of the versions of `onnxruntime` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,9 @@
-{% set suffix = "" %}
 {% set name = "onnxruntime" %}
 {% set cuda_enabled = cuda_compiler_version != "None" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
 {% set version = "1.18.0" %}
 {% set suffix = "" %}  # [suffix == None]
-{% set build = 2 %}
+{% set build = 3 %}
 
 {% if cuda_enabled %}
 {% set build = build + 200 %}


### PR DESCRIPTION
We are currently setting the suffix to `""` unconditionally. This causes the `-novec` variants of the package to not be properly updated on conda-forge; i.e. they are stuck on 1.17.1 while the latest version is 1.18.0. 

Thanks to @janjagusch for figuring this out!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
