### PR TITLE
Bump onnxruntime to 1.24.4 and add Python 3.14

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,38 +8,46 @@ jobs:
     vmImage: $(VMIMAGE)
   strategy:
     matrix:
-      osx_arm64_python3.10.____cpythonsuffix:
-        CONFIG: osx_arm64_python3.10.____cpythonsuffix
-        UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
-      osx_arm64_python3.10.____cpythonsuffix-novec:
-        CONFIG: osx_arm64_python3.10.____cpythonsuffix-novec
-        UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
       osx_arm64_python3.11.____cpythonsuffix:
         CONFIG: osx_arm64_python3.11.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
       osx_arm64_python3.11.____cpythonsuffix-novec:
         CONFIG: osx_arm64_python3.11.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
       osx_arm64_python3.12.____cpythonsuffix:
         CONFIG: osx_arm64_python3.12.____cpythonsuffix
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
       osx_arm64_python3.12.____cpythonsuffix-novec:
         CONFIG: osx_arm64_python3.12.____cpythonsuffix-novec
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
       osx_arm64_python3.13.____cp313suffix:
         CONFIG: osx_arm64_python3.13.____cp313suffix
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
       osx_arm64_python3.13.____cp313suffix-novec:
         CONFIG: osx_arm64_python3.13.____cp313suffix-novec
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_python3.14.____cp314suffix:
+        CONFIG: osx_arm64_python3.14.____cp314suffix
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_python3.14.____cp314suffix-novec:
+        CONFIG: osx_arm64_python3.14.____cp314suffix-novec
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cudnn:
 - '9'
 cxx_compiler:
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- -novec
+- ''
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- ''
+- -novec
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- -novec
+- ''
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,9 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '13.0'
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -29,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - ''
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -13,7 +13,9 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -29,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 suffix:
-- -novec
+- ''
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cudnn:
 - '9'
 cxx_compiler:
@@ -33,9 +33,9 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 suffix:
-- -novec
+- ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- '12.9'
 cudnn:
 - '9'
 cxx_compiler:
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.13.* *_cp313
 suffix:
 - ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -14,6 +14,8 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
+cudnn:
+- '9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -21,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - -novec
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- -novec
+- ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '13.0'
 cudnn:
 - '9'
 cxx_compiler:
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 suffix:
-- -novec
+- ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '13.0'
 cudnn:
 - '9'
 cxx_compiler:
@@ -33,9 +33,9 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 suffix:
-- -novec
+- ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -1,15 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,13 +13,17 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '13.0'
+cudnn:
+- '9'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+github_actions_labels:
+- namespace-profile-16cpu-on-linux-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,13 +31,15 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.13.* *_cp313
 suffix:
-- -novec
+- ''
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '13.0'
 cudnn:
 - '9'
 cxx_compiler:
@@ -31,11 +31,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- -novec
+- ''
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,41 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+        # Manually migrated (e.g. were blocked on missing dev dependencies)
+        - pyarrow
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,16 +18,12 @@ cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
 - None
-cudnn:
-- '9'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
-github_actions_labels:
-- namespace-profile-16cpu-on-linux-64
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '2'
 pin_run_as_build:
@@ -31,15 +31,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - -novec
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cuda_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cudnn:
 - '9'
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -23,9 +23,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- -novec
+- ''
 target_platform:
 - win-64
 zlib:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 cudnn:
 - '9'
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -23,7 +23,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -15,7 +15,7 @@ cudnn:
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -23,9 +23,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
-- ''
+- -novec
 target_platform:
 - win-64
 zlib:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- None
 cudnn:
 - '9'
 cxx_compiler:
 - vs2022
 github_actions_labels:
-- cirun-azure-windows-4xlarge
+- namespace-profile-16cpu-on-win-64
 numpy:
 - '2'
 pin_run_as_build:
@@ -23,7 +23,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.14.* *_cp314
 suffix:
 - ''
 target_platform:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,192 +19,281 @@ jobs:
     timeout-minutes: 720
     strategy:
       fail-fast: false
+      max-parallel: 50
       matrix:
         include:
-          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h8e2e637f', 'linux', 'x64', 'self-hosted']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h02a0b905', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h3f2195fa', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h79007dd3', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix
+          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_hec274bd6', 'linux', 'x64', 'self-hosted']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h3e15d48e', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_hda32efd8', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_hac7426b4', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h13b6b21b', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h81ead3e1', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h3bdfe2b9', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.17cuda_compil_h3a16a43b', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix
+          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.28cuda_compil_hf6803ed7', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.28cuda_compil_he77af15f', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.28cuda_compil_h2b97111d', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_c_stdlib_version2.28cuda_compil_h402f3634', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix
+          - CONFIG: linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_hf3e0d727', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_h6efb9d1d', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_hc780c12b', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_hbbf0cf2c', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_h77f1c47d', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_h8501535b', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_h01618b48', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_aarch64_c_stdlib_version2.17cuda_c_h930b895d', 'linux', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version12.9python3._haca5f550', 'windows', 'x64', 'self-hosted']
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version12.9python3._h2845a0b2', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version12.9python3._h39d4b130', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_version12.9python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version12.9python3._h3665483b', 'windows', 'x64', 'self-hosted']
-          - CONFIG: win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix
+            runs_on: ['namespace-profile-16cpu-on-win-64']
+          - CONFIG: win_64_cuda_compiler_version12.9python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version13.0python3._h475548c6', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version13.0python3._he6270049', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version13.0python3._hb0975f2d', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_version13.0python3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_version13.0python3._h96ebb012', 'windows', 'x64', 'self-hosted']
-          - CONFIG: win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix
+            runs_on: ['namespace-profile-16cpu-on-win-64']
+          - CONFIG: win_64_cuda_compiler_version13.0python3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h9b8b909e', 'windows', 'x64', 'self-hosted']
-          - CONFIG: win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec
-            UPLOAD_PACKAGES: True
-            os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._hb247aade', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h6928eed6', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h4390b1c1', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h7ca8fcdb', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h7e77335f', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.13.____cp313suffix
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._h4998f419', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
           - CONFIG: win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: windows
-            runs_on: ['cirun-azure-windows-4xlarge--${{ github.run_id }}-win_64_cuda_compiler_versionNonepython3._he08fd93b', 'windows', 'x64', 'self-hosted']
+            runs_on: ['namespace-profile-16cpu-on-win-64']
+          - CONFIG: win_64_cuda_compiler_versionNonepython3.14.____cp314suffix
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: windows
+            runs_on: ['namespace-profile-16cpu-on-win-64']
+          - CONFIG: win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: windows
+            runs_on: ['namespace-profile-16cpu-on-win-64']
     steps:
 
     - name: Checkout code
@@ -277,8 +366,8 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: D:\Miniforge
+        CONDA_BLD_PATH: C:\bld
+        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RATTLER_CACHE_DIR="${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache"
 
 cat >~/.condarc <<CONDARC
 
@@ -31,11 +32,19 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,34 +9,24 @@ set -xe
 MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
 MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
 export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
-
-( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
-MICROMAMBA_VERSION="1.5.10-0"
-if [[ "$(uname -m)" == "arm64" ]]; then
-  osx_arch="osx-arm64"
-else
-  osx_arch="osx-64"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
 fi
-MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
-MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
-echo "Downloading micromamba ${MICROMAMBA_VERSION}"
-micromamba_exe="$(mktemp -d)/micromamba"
-curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
-chmod +x "${micromamba_exe}"
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
-  --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
-mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
-echo "Cleaning up micromamba"
-rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
-( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-echo "Activating environment"
-source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
-conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -13,36 +13,49 @@
 setlocal enableextensions enabledelayedexpansion
 
 FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
-if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
+if "%MINIFORGE_HOME%"=="" (
+    set "MINIFORGE_HOME=%REPO_ROOT%\.pixi\envs\default"
+) else (
+    set "PIXI_CACHE_DIR=%MINIFORGE_HOME%"
+)
 :: Remove trailing backslash, if present
 if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
-call :start_group "Provisioning base env with micromamba"
-set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"
-set "MICROMAMBA_VERSION=1.5.10-0"
-set "MICROMAMBA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/%MICROMAMBA_VERSION%/micromamba-win-64"
-set "MICROMAMBA_TMPDIR=%TMP%\micromamba-%RANDOM%"
-set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
-
-echo Downloading micromamba %MICROMAMBA_VERSION%
-if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
+call :start_group "Provisioning base env with pixi"
+echo Installing pixi
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "iwr -useb https://pixi.sh/install.ps1 | iex"
 if !errorlevel! neq 0 exit /b !errorlevel!
-
-echo Creating environment
-call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
-    --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+set "PATH=%USERPROFILE%\.pixi\bin;%PATH%"
+echo Installing environment
+if "%PIXI_CACHE_DIR%"=="%MINIFORGE_HOME%" (
+    mkdir "%MINIFORGE_HOME%"
+    copy /Y pixi.toml "%MINIFORGE_HOME%"
+    pushd "%MINIFORGE_HOME%"
+) else (
+    pushd "%REPO_ROOT%"
+)
+move /y pixi.toml pixi.toml.bak
+set "arch=64"
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.toml.bak -Encoding UTF8) -replace 'platforms = .*', 'platforms = [''win-%arch%'']' | Out-File pixi.toml -Encoding UTF8"
+:: Git on Windows needs to run post link scripts to properly set up SSL certificates
+pixi config set --global run-post-link-scripts insecure
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Removing %MAMBA_ROOT_PREFIX%
-del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
-del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+pixi install
+if !errorlevel! neq 0 exit /b !errorlevel!
+pixi list
+if !errorlevel! neq 0 exit /b !errorlevel!
+set "ACTIVATE_PIXI=%TMP%\pixi-activate-%RANDOM%.bat"
+pixi shell-hook > "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+call "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+move /y pixi.toml.bak pixi.toml
+popd
 call :end_group
 
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
-echo Activating environment
-call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/README.md
+++ b/README.md
@@ -67,13 +67,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
@@ -95,17 +88,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -151,10 +137,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix</td>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -179,17 +172,38 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix</td>
+              <td>linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec</td>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -235,17 +249,45 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.10.____cpythonsuffix</td>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpythonsuffix" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.10.____cpythonsuffix-novec</td>
+              <td>linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpythonsuffix-novec" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -291,10 +333,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix</td>
+              <td>osx_arm64_python3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.14.____cp314suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.14.____cp314suffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.14.____cp314suffix-novec" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -319,10 +368,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix</td>
+              <td>win_64_cuda_compiler_version12.9python3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version12.9python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -347,17 +396,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix</td>
+              <td>win_64_cuda_compiler_version13.0python3.14.____cp314suffix</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_version13.0python3.14.____cp314suffix" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -400,6 +442,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_versionNonepython3.14.____cp314suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonepython3.14.____cp314suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12634&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/onnxruntime-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec" alt="variant">
                 </a>
               </td>
             </tr>

--- a/build-locally.py
+++ b/build-locally.py
@@ -28,13 +28,6 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
-    # The default cache location might not be writable using docker on macOS.
-    if ns.config.startswith("linux") and platform.system() == "Darwin":
-        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
-            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
-            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
-        )
-
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,15 +10,14 @@ azure:
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
-  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
+conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main
 github_actions:
-  self_hosted: true
   timeout_minutes: 720
   triggers:
   - push
@@ -26,4 +25,5 @@ github_actions:
 provider:
   linux_64: github_actions
   win_64: github_actions
+  osx_arm64: default
 test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,553 @@
+# -*- mode: toml -*-
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
+
+[workspace]
+name = "onnxruntime-feedstock"
+version = "3.61.2"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/onnxruntime-feedstock"
+authors = ["@conda-forge/onnxruntime"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+requires-pixi = ">=0.59.0"
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+python = "3.12.*"
+
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in conda-build build directory."
+[tasks.build]
+cmd = "conda-build build recipe"
+description = "Build onnxruntime-feedstock directly (without setup scripts), no particular variant specified"
+[tasks.debug]
+cmd = "conda-build debug recipe"
+description = "Debug onnxruntime-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"
+[tasks."build-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"
+[tasks."build-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"
+[tasks."build-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"
+[tasks."build-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec"
+[tasks."build-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix"
+[tasks."build-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix"
+[tasks."build-osx_arm64_python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.11.____cpythonsuffix"
+[tasks."build-osx_arm64_python3.11.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.11.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.11.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.11.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.11.____cpythonsuffix-novec"
+[tasks."build-osx_arm64_python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.12.____cpythonsuffix"
+[tasks."build-osx_arm64_python3.12.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.12.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.12.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.12.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.12.____cpythonsuffix-novec"
+[tasks."build-osx_arm64_python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.13.____cp313suffix"
+[tasks."build-osx_arm64_python3.13.____cp313suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.13.____cp313suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.13.____cp313suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.13.____cp313suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.13.____cp313suffix-novec"
+[tasks."build-osx_arm64_python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.14.____cp314suffix"
+[tasks."build-osx_arm64_python3.14.____cp314suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.14.____cp314suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant osx_arm64_python3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."debug-osx_arm64_python3.14.____cp314suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant osx_arm64_python3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.14.____cp314suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant osx_arm64_python3.14.____cp314suffix-novec"
+[tasks."build-win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version12.9python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version12.9python3.13.____cp313suffix"
+[tasks."build-win_64_cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version12.9python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version12.9python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version12.9python3.14.____cp314suffix"
+[tasks."build-win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version13.0python3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version13.0python3.13.____cp313suffix"
+[tasks."build-win_64_cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_version13.0python3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_version13.0python3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_version13.0python3.14.____cp314suffix"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix"
+[tasks."build-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build build recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml --suppress-variables --clobber-file .ci_support/clobber_win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Build onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."debug-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "conda-build debug recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "Debug onnxruntime-feedstock with variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec directly (without setup scripts)"
+[tasks."inspect-win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml"
+description = "List contents of onnxruntime-feedstock packages built for variant win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,7 @@ if "%cuda_compiler_version%"=="None" (
     set "onnxruntime_BUILD_UNIT_TESTS=ON"
     set "CUDA_ARCH_LIST="
 ) else (
-    set "BUILD_ARGS=--use_cuda  --cuda_home %LIBRARY_PREFIX% --cudnn_home %LIBRARY_PREFIX% --nvcc_threads=1 --parallel=0 --parallel=4"
+    set "BUILD_ARGS=--use_cuda  --cuda_home %LIBRARY_PREFIX% --cudnn_home %LIBRARY_PREFIX% --nvcc_threads=4 --parallel=8"
     set "onnxruntime_BUILD_UNIT_TESTS=OFF"
     if "%cuda_compiler_version%"=="12.9" (
         set "CUDA_ARCH_LIST=70-real;75-real;80-real;86-real;89-real;90-real;100-real;120"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-BUILD_ARGS="--skip_pip_install --parallel=4"
+BUILD_ARGS="--skip_pip_install --parallel=8"
 
 if [[ "${PKG_NAME}" == 'onnxruntime-novec' ]]; then
     DONT_VECTORIZE="ON"
@@ -78,7 +78,7 @@ if [[ ! -z "${cuda_compiler_version+x}" && "${cuda_compiler_version}" != "None" 
             exit 1
     esac
     export CUDA_HOME="${BUILD_PREFIX}/targets/${CUDA_TARGET}"
-    BUILD_ARGS="${BUILD_ARGS} --use_cuda --cuda_home ${CUDA_HOME} --cudnn_home ${PREFIX}"
+    BUILD_ARGS="${BUILD_ARGS} --use_cuda --cuda_home ${CUDA_HOME} --cudnn_home ${PREFIX} --nvcc_threads=4"
     export NINJAJOBS=1
     cmake_extra_defines+=( "CMAKE_CUDA_COMPILER=${BUILD_PREFIX}/bin/nvcc" \
 			   "CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH_LIST}"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,6 @@ suffix:
 - ''
 - -novec
 
-github_actions_labels:          # [linux or win]
-- cirun-openstack-cpu-4xlarge   # [linux]
-- cirun-azure-windows-4xlarge   # [win]
+github_actions_labels:                # [linux or win]
+- namespace-profile-16cpu-on-linux-64 # [linux]
+- namespace-profile-16cpu-on-win-64   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set cuda_enabled = cuda_compiler_version != "None" %}
 {% set build_ext = ("cuda" ~ cuda_compiler_version).replace(".", "") if cuda_enabled else "cpu" %}
-{% set version = "1.24.2" %}
+{% set version = "1.24.4" %}
 {% set suffix = "" %}  # [suffix == None]
 {% set build = 0 %}
 
@@ -20,7 +20,7 @@ package:
 
 source:
   url: https://github.com/microsoft/onnxruntime/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e4f44579f0bdd06d1cc7abdb2a6740dc06ac10699d502c0f8d9576203550bd4d
+  sha256: 0cf4d2ee4392fbb8aedaabc6b2ba11b4a680d1071fa4f75546c2289ca5b404cf
   patches:
     # Workaround for https://github.com/conda-forge/onnxruntime-feedstock/pull/56#issuecomment-1586080419
     - patches/0001-avoid-conflicting-with-onnxruntime.dll-in-system32.patch     # [win]
@@ -35,12 +35,11 @@ source:
 build:
   number: {{ build }}
   # don't build cuda versions with novec
-  skip: true  # [ (cuda_compiler_version != "None") and suffix == "-novec" ]
-  # cross-compilation of linux-aarch64 cuda builds are currently broken
-  skip: true  # [(cuda_compiler_version != "None") and aarch64]
+  skip: true  # [ (cuda_compiler_version != "None") and suffix == "-novec"]
   # Since 1.11, power9 seems to be required.
   skip: true  # [ppc64le]
-  skip: true  # [osx and x86_64]  # No longer supported upstream and tests fail
+  skip: true  # [osx and x86_64]
+  skip: true  # [py < 311]  # upstream requires python >= 3.11 since 1.24.4
   string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
   ignore_run_exports_from:
     - zlib
@@ -92,7 +91,6 @@ requirements:
     - numpy
     - pybind11
   run:
-    - coloredlogs
     - packaging
     - protobuf
     - python


### PR DESCRIPTION
## Summary
- Bumps onnxruntime from 1.24.2 to 1.24.4
- Adds Python 3.14 support (drops Python 3.10 — upstream now requires `>= 3.11`)
- Switches Linux runners from decommissioned `cirun-openstack-cpu-4xlarge` to Cirrus runners (`ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg`)
- Removes deprecated `self_hosted` from `conda-forge.yml` (fixes linter warning)
- Re-rendered with conda-smithy 3.59.0

## Motivation
The Python 3.14 migration PR (#163) was blocked by a segfault in onnxruntime on Python 3.14 (upstream issue microsoft/onnxruntime#27392). This was fixed upstream in v1.24.3 via microsoft/onnxruntime#27413 (refcount bug in map input conversion). The reporter confirmed the fix on win-64, linux-64, and osx-arm64.

v1.24.4 is a patch release containing additional bug fixes. It also bumps `python_requires` to `>= 3.11`, so Python 3.10 is dropped from the build matrix.

All 4 existing patches were verified to still apply cleanly to v1.24.4.

## CI runner changes
The Quansight Open GPU Server (OpenStack) was decommissioned on 2026-03-13 (conda-forge/.cirun#174), causing all Linux GHA jobs to time out after 24h waiting for runners that no longer exist. This PR switches Linux builds to Cirrus runners (access granted via conda-forge/admin-requests#1982). Windows builds remain on `cirun-azure-windows-4xlarge`.

Supersedes #163 and #176.

## Test plan
- [x] osx-arm64 builds pass (all Python versions including 3.14)
- [x] Linux builds pass on Cirrus runners
- [x] Windows builds pass on cirun-azure
- [x] Python 3.10 builds are correctly skipped