### PR TITLE
Unvendor bundled C++ deps (protobuf, abseil, onnx, re2, flatbuffers, coremltools)

### DIFF
--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.28'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-linux-64
 libabseil:

--- a/.ci_support/migrations/absl_grpc_proto_26Q1.yaml
+++ b/.ci_support/migrations/absl_grpc_proto_26Q1.yaml
@@ -1,0 +1,35 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20260107, libgrpc 1.78 & libprotobuf 6.33.5
+  kind: version
+  migration_number: 1
+  exclude:
+    # core deps
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    # required for building/testing
+    - protobuf
+    - re2
+    # bazel stack
+    - bazel
+    - grpc_java_plugin
+    - singlejar
+    # built manually beforehand due to enormous build time
+    - pytorch-cpu
+libabseil:
+- 20260107
+libgrpc:
+- "1.78"
+libprotobuf:
+- 6.33.5
+# we add re2 because even though its ABI didn't change,
+# we need a version that's been rebuilt for matching abseil
+re2:
+- 2025.11.05
+# we need to leave this migration open until we're ready to move the global baseline, see
+# https://github.com/conda-forge/conda-forge.github.io/issues/2467; grpc 1.72 requires 11.0,
+# see https://github.com/grpc/grpc/commit/f122d248443c81592e748da1adb240cbf0a0231c
+c_stdlib_version:   # [osx]
+  - 11.0            # [osx]
+migrator_ts: 1768184504.2078037

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpythonsuffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix-novec.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libprotobuf:
+- 6.33.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+flatbuffers:
+- 25.9.23
 libabseil:
 - '20260107'
 libprotobuf:

--- a/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314suffix.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 macos_machine:
@@ -34,6 +36,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.10.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.11.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.12.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.13.____cp313suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9python3.14.____cp314suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.10.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.11.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.12.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.13.____cp313suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0python3.14.____cp314suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix-novec.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix-novec.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix-novec.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpythonsuffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix-novec.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix-novec.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - -novec
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libabseil:
+- '20260107'
 libprotobuf:
 - 6.33.5
 numpy:
@@ -26,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+re2:
+- 2025.11.05
 suffix:
 - ''
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,mark.harfouche
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -16,6 +16,8 @@ cxx_compiler:
 - vs2022
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
+libprotobuf:
+- 6.33.5
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.14.____cp314suffix.yaml
@@ -14,6 +14,8 @@ cudnn:
 - '9'
 cxx_compiler:
 - vs2022
+flatbuffers:
+- 25.9.23
 github_actions_labels:
 - namespace-profile-16cpu-on-win-64
 libabseil:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ About onnxruntime
 
 Home: https://github.com/microsoft/onnxruntime/
 
-Package license: MIT AND BSL-1.0 AND BSD-3-Clause
+Package license: MIT AND BSL-1.0
 
 Summary: cross-platform, high performance ML inferencing and training accelerator
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -92,6 +92,13 @@ if [[ ! -z "${cuda_compiler_version+x}" && "${cuda_compiler_version}" != "None" 
 
 fi
 
+# onnxruntime is built against the conda-forge flatbuffers instead of the
+# vendored copy. The flatbuffers schema headers checked into the source tree
+# carry a static_assert pinning them to flatbuffers 23.5.26, so regenerate
+# them with the conda flatc to match the conda flatbuffers runtime version.
+python onnxruntime/core/flatbuffers/schema/compile_schema.py --flatc "${BUILD_PREFIX}/bin/flatc" --language cpp
+python onnxruntime/lora/adapter_format/compile_schema.py --flatc "${BUILD_PREFIX}/bin/flatc"
+
 python tools/ci_build/build.py \
     --compile_no_warning_as_error \
     --enable_lto \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,9 +42,6 @@ cmake_extra_defines=( "EIGEN_MPL2_ONLY=ON" \
                       "CMAKE_PREFIX_PATH=$PREFIX" \
                       "CMAKE_CXX_STANDARD=20" \
 		      "CMAKE_INSTALL_LIBDIR=lib" \
-                      `# The conda-forge libonnx (and libprotobuf) are full` \
-                      `# protobuf builds, so onnxruntime must link the full` \
-                      `# libprotobuf too, not libprotobuf-lite.` \
                       "onnxruntime_USE_FULL_PROTOBUF=ON"
 )
 
@@ -92,10 +89,7 @@ if [[ ! -z "${cuda_compiler_version+x}" && "${cuda_compiler_version}" != "None" 
 
 fi
 
-# onnxruntime is built against the conda-forge flatbuffers instead of the
-# vendored copy. The flatbuffers schema headers checked into the source tree
-# carry a static_assert pinning them to flatbuffers 23.5.26, so regenerate
-# them with the conda flatc to match the conda flatbuffers runtime version.
+# regenerate with conda-forge flatc
 python onnxruntime/core/flatbuffers/schema/compile_schema.py --flatc "${BUILD_PREFIX}/bin/flatc" --language cpp
 python onnxruntime/lora/adapter_format/compile_schema.py --flatc "${BUILD_PREFIX}/bin/flatc"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,15 +10,14 @@ else
     DONT_VECTORIZE="OFF"
 fi
 
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == '1' || "${cuda_compiler_version:-None}" != "None" ]]; then
-    echo "Tests are disabled"
-    RUN_TESTS_BUILD_PY_OPTIONS=""
-    BUILD_UNIT_TESTS="OFF"
-else
-    echo "Tests are enabled"
-    RUN_TESTS_BUILD_PY_OPTIONS="--test"
-    BUILD_UNIT_TESTS="ON"
-fi
+# The C++ unit tests build an onnx_test_data_proto target that imports ONNX's
+# .proto source files. The unvendored conda-forge libonnx package ships only
+# the generated headers, not the .proto sources, so the unit tests cannot be
+# built. Skip them; the recipe's own test section still exercises the Python
+# package, the C++ consumer test and cmake-package-check.
+echo "Compiled unit tests are disabled"
+RUN_TESTS_BUILD_PY_OPTIONS=""
+BUILD_UNIT_TESTS="OFF"
 
 if [[ "${target_platform:-other}" == 'osx-arm64' ]]; then
     BUILD_ARGS="${BUILD_ARGS} --osx_arch arm64"
@@ -42,7 +41,11 @@ cmake_extra_defines=( "EIGEN_MPL2_ONLY=ON" \
                       "onnxruntime_BUILD_UNIT_TESTS=$BUILD_UNIT_TESTS" \
                       "CMAKE_PREFIX_PATH=$PREFIX" \
                       "CMAKE_CXX_STANDARD=20" \
-		      "CMAKE_INSTALL_LIBDIR=lib"
+		      "CMAKE_INSTALL_LIBDIR=lib" \
+                      `# The conda-forge libonnx (and libprotobuf) are full` \
+                      `# protobuf builds, so onnxruntime must link the full` \
+                      `# libprotobuf too, not libprotobuf-lite.` \
+                      "onnxruntime_USE_FULL_PROTOBUF=ON"
 )
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,14 +20,23 @@ fi
 # CUDA build (no GPU available to run the suite), matching the pre-unvendoring
 # behaviour.
 ONNX_PROTO_ROOT="$(dirname "$(dirname "$(find "${PREFIX}" -path '*/onnx/onnx-ml.proto' 2>/dev/null | head -1)")")"
+# We build and run the C++ unit tests (ctest) but NOT build.py's python test
+# phase: that phase runs ONNX conformance + onnxruntime.quantization tooling
+# tests which are brittle against the unvendored external onnx (e.g. onnx 1.21
+# raises NotImplementedError on a BatchNormalization op shared across the '' and
+# 'com.ms.internal.nhwc' domains, and the onnx backend series expects vendored
+# test data). The C++ ctest suite is the meaningful unit-test coverage and
+# passes against the unvendored onnx. Tests are skipped entirely when cross
+# compiling or for the CUDA build (no GPU to run them).
+RUN_TESTS_BUILD_PY_OPTIONS=""   # never let build.py run its (python) test phase
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == '1' || "${cuda_compiler_version:-None}" != "None" || -z "${ONNX_PROTO_ROOT}" ]]; then
     echo "Compiled unit tests are disabled"
-    RUN_TESTS_BUILD_PY_OPTIONS=""
     BUILD_UNIT_TESTS="OFF"
+    RUN_CPP_CTEST="no"
 else
     echo "Compiled unit tests are enabled (onnx .proto from ${ONNX_PROTO_ROOT})"
-    RUN_TESTS_BUILD_PY_OPTIONS="--test"
     BUILD_UNIT_TESTS="ON"
+    RUN_CPP_CTEST="yes"
 fi
 
 if [[ "${target_platform:-other}" == 'osx-arm64' ]]; then
@@ -124,6 +133,14 @@ python tools/ci_build/build.py \
     --skip_submodule_sync \
     --path_to_protoc_exe $BUILD_PREFIX/bin/protoc \
     ${BUILD_ARGS}
+
+# Run the C++ unit tests directly via ctest (build.py's python test phase is
+# intentionally not invoked; see the BUILD_UNIT_TESTS block above). The test
+# binaries link the just-built and host shared libs.
+if [[ "${RUN_CPP_CTEST}" == "yes" ]]; then
+    LD_LIBRARY_PATH="${PREFIX}/lib:${SRC_DIR}/build-ci/Release:${LD_LIBRARY_PATH:-}" \
+        ctest --test-dir build-ci/Release --output-on-failure --parallel "${CPU_COUNT:-4}"
+fi
 
 # Install the project into cwd.
 # This is needed only to produce the exported CMake targets.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,14 +10,25 @@ else
     DONT_VECTORIZE="OFF"
 fi
 
-# The C++ unit tests build an onnx_test_data_proto target that imports ONNX's
-# .proto source files. The unvendored conda-forge libonnx package ships only
-# the generated headers, not the .proto sources, so the unit tests cannot be
-# built. Skip them; the recipe's own test section still exercises the Python
-# package, the C++ consumer test and cmake-package-check.
-echo "Compiled unit tests are disabled"
-RUN_TESTS_BUILD_PY_OPTIONS=""
-BUILD_UNIT_TESTS="OFF"
+# The C++ unit tests build an onnx_test_data_proto target whose tml.proto
+# imports ONNX's .proto source files (onnx/onnx-ml.proto). onnxruntime locates
+# them via the cmake variable onnx_SOURCE_DIR. The unvendored conda libonnx
+# package ships only the generated headers, but the conda-forge `onnx` (Python)
+# package ships the .proto sources under
+# $PREFIX/lib/pythonX.Y/site-packages/onnx/, so point onnx_SOURCE_DIR there
+# instead of re-vendoring onnx. Disabled only when cross compiling or for the
+# CUDA build (no GPU available to run the suite), matching the pre-unvendoring
+# behaviour.
+ONNX_PROTO_ROOT="$(dirname "$(dirname "$(find "${PREFIX}" -path '*/onnx/onnx-ml.proto' 2>/dev/null | head -1)")")"
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == '1' || "${cuda_compiler_version:-None}" != "None" || -z "${ONNX_PROTO_ROOT}" ]]; then
+    echo "Compiled unit tests are disabled"
+    RUN_TESTS_BUILD_PY_OPTIONS=""
+    BUILD_UNIT_TESTS="OFF"
+else
+    echo "Compiled unit tests are enabled (onnx .proto from ${ONNX_PROTO_ROOT})"
+    RUN_TESTS_BUILD_PY_OPTIONS="--test"
+    BUILD_UNIT_TESTS="ON"
+fi
 
 if [[ "${target_platform:-other}" == 'osx-arm64' ]]; then
     BUILD_ARGS="${BUILD_ARGS} --osx_arch arm64"
@@ -44,6 +55,13 @@ cmake_extra_defines=( "EIGEN_MPL2_ONLY=ON" \
 		      "CMAKE_INSTALL_LIBDIR=lib" \
                       "onnxruntime_USE_FULL_PROTOBUF=ON"
 )
+
+# When building the unit tests, tell onnxruntime where to find ONNX's .proto
+# sources (shipped by the conda `onnx` package) so the onnx_test_data_proto
+# target can be generated against the unvendored onnx.
+if [[ "${BUILD_UNIT_TESTS}" == "ON" ]]; then
+    cmake_extra_defines+=( "onnx_SOURCE_DIR=${ONNX_PROTO_ROOT}" )
+fi
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)
 # into --cmake_extra_defines.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,3 +12,9 @@ MACOSX_SDK_VERSION:  # [osx]
 github_actions_labels:                # [linux or win]
 - namespace-profile-16cpu-on-linux-64 # [linux]
 - namespace-profile-16cpu-on-win-64   # [win]
+
+# TEMPORARY: also pull from the mark.harfouche channel so the CoreML
+# execution provider can use the libcoremltools package before it is
+# published on conda-forge. Remove before merging.
+channel_sources:
+- conda-forge,mark.harfouche

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ source:
     - patches/0004-Remove-redundant-include-paths-from-custom-op-test-t.patch
     # Upstream is actually compatible with 3.10
     - patches/0005-Lower-python_require-to-3.10.patch
+    # Use the conda-forge libcoremltools package instead of vendoring the
+    # coremltools sources for the CoreML execution provider.
+    - patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch  # [osx and arm64]
 
 build:
   number: {{ build }}
@@ -66,7 +69,7 @@ requirements:
     - cmake <4
     - ninja
     # we need protoc in the build environment for cross compilations
-    - libprotobuf 3.21
+    - libprotobuf
   host:
     - python
     - pip
@@ -91,6 +94,9 @@ requirements:
     # Used by the CoreML execution provider to build mlpackage models;
     # onnxruntime finds it via find_package, so prefer the conda-forge build.
     - nlohmann_json  # [osx and arm64]
+    # The CoreML execution provider links libcoremltools (MILBlob +
+    # modelpackage helpers) instead of vendoring the coremltools sources.
+    - libcoremltools  # [osx and arm64]
     - zlib
     - numpy
     - pybind11
@@ -169,8 +175,7 @@ outputs:
 about:
   home: https://github.com/microsoft/onnxruntime/
   summary: cross-platform, high performance ML inferencing and training accelerator
-  license: MIT AND BSL-1.0                   # [not (osx and arm64)]  # mp11 is BSL 1.0
-  license: MIT AND BSL-1.0 AND BSD-3-Clause  # [osx and arm64]        # mp11 is BSL 1.0, coremltools is BSD-3-Clause
+  license: MIT AND BSL-1.0  # mp11 is BSL 1.0
   license_file:
     - LICENSE
     - build-ci/Release/_deps/abseil_cpp-src/LICENSE
@@ -183,10 +188,10 @@ about:
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
     - build-ci/Release/_deps/re2-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE
-    # Vendored at build time by onnxruntime for the CoreML execution provider.
-    - build-ci/Release/_deps/coremltools-src/LICENSE.txt  # [osx and arm64]
-    - build-ci/Release/_deps/fp16-src/LICENSE             # [osx and arm64]
-    - build-ci/Release/_deps/psimd-src/LICENSE            # [osx and arm64]
+    # Fetched at build time by onnxruntime for the CoreML execution provider.
+    # coremltools itself is provided by the linked libcoremltools package.
+    - build-ci/Release/_deps/fp16-src/LICENSE   # [osx and arm64]
+    - build-ci/Release/_deps/psimd-src/LICENSE  # [osx and arm64]
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ source:
     # Use the conda-forge libcoremltools package instead of vendoring the
     # coremltools sources for the CoreML execution provider.
     - patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch  # [osx and arm64]
+    # Use the conda-forge libabseil package instead of the vendored abseil.
+    - patches/0007-Use-the-conda-forge-libabseil-package.patch
 
 build:
   number: {{ build }}
@@ -88,6 +90,13 @@ requirements:
     - flake8
     - gmock
     - libdate
+    # Link the conda-forge protobuf and abseil shared libraries instead of the
+    # sources vendored by onnxruntime. onnxruntime finds both via find_package
+    # (CMAKE_PREFIX_PATH=$PREFIX). libcoremltools depends on this exact
+    # libprotobuf/libabseil pair, so all of the CoreML execution provider's
+    # dependencies resolve to one self-consistent stack.
+    - libabseil
+    - libprotobuf
     - packaging
     - python-flatbuffers
     - optional-lite
@@ -141,6 +150,14 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('cuda') }}  # [cuda_compiler_version != "None"]
+      host:
+        # This output ships libonnxruntime, which dynamically links the
+        # conda-forge protobuf/abseil/coremltools shared libraries (they are no
+        # longer vendored). Listing them here lets their run_exports add the
+        # matching runtime dependencies to this output.
+        - libabseil
+        - libprotobuf
+        - libcoremltools  # [osx and arm64]
       run:
         - __cuda    # [cuda_compiler_version != "None"]
       run_constrained:
@@ -178,13 +195,13 @@ about:
   license: MIT AND BSL-1.0  # mp11 is BSL 1.0
   license_file:
     - LICENSE
-    - build-ci/Release/_deps/abseil_cpp-src/LICENSE
     - build-ci/Release/_deps/eigen3-src/COPYING.MPL2
     - build-ci/Release/_deps/flatbuffers-src/LICENSE
     - build-ci/Release/_deps/gsl-src/LICENSE
     - build-ci/Release/_deps/nlohmann_json-src/LICENSE.MIT  # [not unix]
     - build-ci/Release/_deps/onnx-src/LICENSE
-    - build-ci/Release/_deps/protobuf-src/LICENSE
+    # abseil and protobuf are no longer vendored; their licenses ship with the
+    # conda-forge libabseil and libprotobuf packages.
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
     - build-ci/Release/_deps/re2-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,11 +93,11 @@ requirements:
     - flake8
     - gmock
     - libdate
-    # Link the conda-forge onnx/protobuf/abseil shared libraries instead of the
-    # sources vendored by onnxruntime. onnxruntime finds them via find_package
-    # (CMAKE_PREFIX_PATH=$PREFIX). libonnx and libcoremltools depend on this
-    # exact libprotobuf/libabseil pair, so all of the dependencies resolve to
-    # one self-consistent (full-protobuf) stack.
+    # Link the conda-forge onnx/protobuf/abseil/re2 shared libraries instead of
+    # the sources vendored by onnxruntime. onnxruntime finds them via
+    # find_package (CMAKE_PREFIX_PATH=$PREFIX). libonnx and libcoremltools
+    # depend on this exact libprotobuf/libabseil pair, so all of the
+    # dependencies resolve to one self-consistent (full-protobuf) stack.
     #
     # Known limitation: the conda-forge libonnx does not carry onnxruntime's
     # vendored patch that un-deprecates the opset-18 GroupNormalization op, so
@@ -107,6 +107,7 @@ requirements:
     - libabseil
     - libprotobuf
     - libonnx
+    - re2
     - packaging
     - python-flatbuffers
     - optional-lite
@@ -168,6 +169,7 @@ outputs:
         - libabseil
         - libprotobuf
         - libonnx
+        - re2
         - libcoremltools  # [osx and arm64]
       run:
         - __cuda    # [cuda_compiler_version != "None"]
@@ -210,10 +212,10 @@ about:
     - build-ci/Release/_deps/flatbuffers-src/LICENSE
     - build-ci/Release/_deps/gsl-src/LICENSE
     - build-ci/Release/_deps/nlohmann_json-src/LICENSE.MIT  # [not unix]
-    # onnx, abseil and protobuf are no longer vendored; their licenses ship
-    # with the conda-forge libonnx, libabseil and libprotobuf packages.
+    # onnx, abseil, protobuf and re2 are no longer vendored; their licenses
+    # ship with the conda-forge libonnx, libabseil, libprotobuf and re2
+    # packages.
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
-    - build-ci/Release/_deps/re2-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE
     # Fetched at build time by onnxruntime for the CoreML execution provider.
     # coremltools itself is provided by the linked libcoremltools package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ source:
     - patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch  # [osx and arm64]
     # Use the conda-forge libabseil package instead of the vendored abseil.
     - patches/0007-Use-the-conda-forge-libabseil-package.patch
+    # Use the conda-forge libonnx package instead of the vendored onnx: skip
+    # onnxruntime's schema registration when onnx registers schemas statically.
+    - patches/0008-Skip-ONNX-schema-registration-when-static.patch
 
 build:
   number: {{ build }}
@@ -90,13 +93,14 @@ requirements:
     - flake8
     - gmock
     - libdate
-    # Link the conda-forge protobuf and abseil shared libraries instead of the
-    # sources vendored by onnxruntime. onnxruntime finds both via find_package
-    # (CMAKE_PREFIX_PATH=$PREFIX). libcoremltools depends on this exact
-    # libprotobuf/libabseil pair, so all of the CoreML execution provider's
-    # dependencies resolve to one self-consistent stack.
+    # Link the conda-forge onnx/protobuf/abseil shared libraries instead of the
+    # sources vendored by onnxruntime. onnxruntime finds them via find_package
+    # (CMAKE_PREFIX_PATH=$PREFIX). libonnx and libcoremltools depend on this
+    # exact libprotobuf/libabseil pair, so all of the dependencies resolve to
+    # one self-consistent (full-protobuf) stack.
     - libabseil
     - libprotobuf
+    - libonnx
     - packaging
     - python-flatbuffers
     - optional-lite
@@ -152,11 +156,12 @@ outputs:
         - {{ compiler('cuda') }}  # [cuda_compiler_version != "None"]
       host:
         # This output ships libonnxruntime, which dynamically links the
-        # conda-forge protobuf/abseil/coremltools shared libraries (they are no
-        # longer vendored). Listing them here lets their run_exports add the
-        # matching runtime dependencies to this output.
+        # conda-forge onnx/protobuf/abseil/coremltools shared libraries (they
+        # are no longer vendored). Listing them here lets their run_exports add
+        # the matching runtime dependencies to this output.
         - libabseil
         - libprotobuf
+        - libonnx
         - libcoremltools  # [osx and arm64]
       run:
         - __cuda    # [cuda_compiler_version != "None"]
@@ -199,9 +204,8 @@ about:
     - build-ci/Release/_deps/flatbuffers-src/LICENSE
     - build-ci/Release/_deps/gsl-src/LICENSE
     - build-ci/Release/_deps/nlohmann_json-src/LICENSE.MIT  # [not unix]
-    - build-ci/Release/_deps/onnx-src/LICENSE
-    # abseil and protobuf are no longer vendored; their licenses ship with the
-    # conda-forge libabseil and libprotobuf packages.
+    # onnx, abseil and protobuf are no longer vendored; their licenses ship
+    # with the conda-forge libonnx, libabseil and libprotobuf packages.
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
     - build-ci/Release/_deps/re2-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,9 @@ requirements:
     - ninja
     # we need protoc in the build environment for cross compilations
     - libprotobuf
+    # flatc (from flatbuffers) regenerates the schema headers in build.sh and
+    # must run on the build platform when cross compiling
+    - flatbuffers
   host:
     - python
     - pip
@@ -108,6 +111,9 @@ requirements:
     - libprotobuf
     - libonnx
     - re2
+    # flatbuffers is statically linked into libonnxruntime (no run dependency);
+    # it is here so onnxruntime finds its headers and CMake package.
+    - flatbuffers
     - packaging
     - python-flatbuffers
     - optional-lite
@@ -209,12 +215,11 @@ about:
   license_file:
     - LICENSE
     - build-ci/Release/_deps/eigen3-src/COPYING.MPL2
-    - build-ci/Release/_deps/flatbuffers-src/LICENSE
     - build-ci/Release/_deps/gsl-src/LICENSE
     - build-ci/Release/_deps/nlohmann_json-src/LICENSE.MIT  # [not unix]
-    # onnx, abseil, protobuf and re2 are no longer vendored; their licenses
-    # ship with the conda-forge libonnx, libabseil, libprotobuf and re2
-    # packages.
+    # onnx, abseil, protobuf, re2 and flatbuffers are no longer vendored; their
+    # licenses ship with the conda-forge libonnx, libabseil, libprotobuf, re2
+    # and flatbuffers packages.
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE
     # Fetched at build time by onnxruntime for the CoreML execution provider.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,12 @@ requirements:
     # (CMAKE_PREFIX_PATH=$PREFIX). libonnx and libcoremltools depend on this
     # exact libprotobuf/libabseil pair, so all of the dependencies resolve to
     # one self-consistent (full-protobuf) stack.
+    #
+    # Known limitation: the conda-forge libonnx does not carry onnxruntime's
+    # vendored patch that un-deprecates the opset-18 GroupNormalization op, so
+    # models with an ai.onnx GroupNormalization node at opset 18-20 are rejected
+    # (INVALID_GRAPH); re-export or version-convert them to opset >= 21. Rare in
+    # practice -- mainstream exporters decompose group norm rather than emit it.
     - libabseil
     - libprotobuf
     - libonnx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,13 +33,8 @@ source:
     - patches/0004-Remove-redundant-include-paths-from-custom-op-test-t.patch
     # Upstream is actually compatible with 3.10
     - patches/0005-Lower-python_require-to-3.10.patch
-    # Use the conda-forge libcoremltools package instead of vendoring the
-    # coremltools sources for the CoreML execution provider.
     - patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch  # [osx and arm64]
-    # Use the conda-forge libabseil package instead of the vendored abseil.
     - patches/0007-Use-the-conda-forge-libabseil-package.patch
-    # Use the conda-forge libonnx package instead of the vendored onnx: skip
-    # onnxruntime's schema registration when onnx registers schemas statically.
     - patches/0008-Skip-ONNX-schema-registration-when-static.patch
 
 build:
@@ -96,12 +91,6 @@ requirements:
     - flake8
     - gmock
     - libdate
-    # Link the conda-forge onnx/protobuf/abseil/re2 shared libraries instead of
-    # the sources vendored by onnxruntime. onnxruntime finds them via
-    # find_package (CMAKE_PREFIX_PATH=$PREFIX). libonnx and libcoremltools
-    # depend on this exact libprotobuf/libabseil pair, so all of the
-    # dependencies resolve to one self-consistent (full-protobuf) stack.
-    #
     # Known limitation: the conda-forge libonnx does not carry onnxruntime's
     # vendored patch that un-deprecates the opset-18 GroupNormalization op, so
     # models with an ai.onnx GroupNormalization node at opset 18-20 are rejected
@@ -111,8 +100,6 @@ requirements:
     - libprotobuf
     - libonnx
     - re2
-    # flatbuffers is statically linked into libonnxruntime (no run dependency);
-    # it is here so onnxruntime finds its headers and CMake package.
     - flatbuffers
     - packaging
     - python-flatbuffers
@@ -120,8 +107,6 @@ requirements:
     # Used by the CoreML execution provider to build mlpackage models;
     # onnxruntime finds it via find_package, so prefer the conda-forge build.
     - nlohmann_json  # [osx and arm64]
-    # The CoreML execution provider links libcoremltools (MILBlob +
-    # modelpackage helpers) instead of vendoring the coremltools sources.
     - libcoremltools  # [osx and arm64]
     - zlib
     - numpy
@@ -167,16 +152,6 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('cuda') }}  # [cuda_compiler_version != "None"]
-      host:
-        # This output ships libonnxruntime, which dynamically links the
-        # conda-forge onnx/protobuf/abseil/coremltools shared libraries (they
-        # are no longer vendored). Listing them here lets their run_exports add
-        # the matching runtime dependencies to this output.
-        - libabseil
-        - libprotobuf
-        - libonnx
-        - re2
-        - libcoremltools  # [osx and arm64]
       run:
         - __cuda    # [cuda_compiler_version != "None"]
       run_constrained:
@@ -217,13 +192,8 @@ about:
     - build-ci/Release/_deps/eigen3-src/COPYING.MPL2
     - build-ci/Release/_deps/gsl-src/LICENSE
     - build-ci/Release/_deps/nlohmann_json-src/LICENSE.MIT  # [not unix]
-    # onnx, abseil, protobuf, re2 and flatbuffers are no longer vendored; their
-    # licenses ship with the conda-forge libonnx, libabseil, libprotobuf, re2
-    # and flatbuffers packages.
     - build-ci/Release/_deps/pytorch_cpuinfo-src/LICENSE
     - build-ci/Release/_deps/safeint-src/LICENSE
-    # Fetched at build time by onnxruntime for the CoreML execution provider.
-    # coremltools itself is provided by the linked libcoremltools package.
     - build-ci/Release/_deps/fp16-src/LICENSE   # [osx and arm64]
     - build-ci/Release/_deps/psimd-src/LICENSE  # [osx and arm64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,15 @@ requirements:
     - libabseil
     - libprotobuf
     - libonnx
+    # The conda `onnx` (Python) package supplies ONNX's .proto sources for the
+    # onnx_test_data_proto unit-test target (see build.sh; onnx_SOURCE_DIR). At
+    # python-test runtime it must also be an onnx that links the SHARED libonnx,
+    # so it shares the onnx-ml.proto descriptors with onnxruntime; an onnx that
+    # statically embeds its own onnx registers onnx-ml.proto twice and aborts.
+    # conda-forge's onnx gains shared-libonnx linkage with the libonnx split
+    # (onnx-feedstock PR #146, build >=1). TEMPORARY: drop the `*_1` build pin
+    # once that lands on conda-forge (conda-forge's current onnx is build 0).
+    - onnx 1.21.0 *_1
     - re2
     - flatbuffers
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,13 +132,22 @@ requirements:
 test:
   imports:
     - onnxruntime
+  files:
+    - test_onnxruntime_inference.py
   commands:
     - pip check
     - onnxruntime_test --help
     # The CoreML execution provider is built into onnxruntime on Apple Silicon.
     - python -c "import onnxruntime as ort; assert 'CoreMLExecutionProvider' in ort.get_available_providers(), ort.get_available_providers()"  # [osx and arm64]
+    # Runtime smoke test on the always-available CPUExecutionProvider: import
+    # onnx and onnxruntime into one process (guards the unvendored libonnx
+    # schema-registration wiring -- see patch 0008) and run real inference.
+    - python test_onnxruntime_inference.py
   requires:
     - pip
+    # onnx builds the tiny test model; importing it alongside onnxruntime also
+    # exercises the shared-libonnx coexistence the unvendoring relies on.
+    - onnx
     # 2024/05 hmaarrfk/jtilly
     # Test the pip check command with numpy < 2
     # which was included in the requirements file for

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,14 +100,13 @@ requirements:
     - libprotobuf
     - libonnx
     # The conda `onnx` (Python) package supplies ONNX's .proto sources for the
-    # onnx_test_data_proto unit-test target (see build.sh; onnx_SOURCE_DIR). At
-    # python-test runtime it must also be an onnx that links the SHARED libonnx,
-    # so it shares the onnx-ml.proto descriptors with onnxruntime; an onnx that
-    # statically embeds its own onnx registers onnx-ml.proto twice and aborts.
-    # conda-forge's onnx gains shared-libonnx linkage with the libonnx split
-    # (onnx-feedstock PR #146, build >=1). TEMPORARY: drop the `*_1` build pin
-    # once that lands on conda-forge (conda-forge's current onnx is build 0).
-    - onnx 1.21.0 *_1
+    # onnx_test_data_proto C++ unit-test target (see build.sh; onnx_SOURCE_DIR).
+    # build.py's python test phase is not run, so we don't import python onnx
+    # alongside onnxruntime here and any onnx providing the .proto suffices.
+    # (At python *runtime*, sharing onnx-ml.proto with onnxruntime needs an onnx
+    # that links the shared libonnx -- onnx-feedstock PR #146; not required for
+    # this build.)
+    - onnx
     - re2
     - flatbuffers
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,6 +152,19 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('cuda') }}  # [cuda_compiler_version != "None"]
+      host:
+        # libonnxruntime.so links these now-unvendored shared libraries
+        # (libonnx.so, libprotobuf.so, libabsl_*.so, libre2.so). The main
+        # onnxruntime output picks them up automatically because it compiles
+        # libonnxruntime.so, but this output only repackages the prebuilt libs
+        # via install-cpp.sh, so conda-build cannot infer them. List them here
+        # so their run_exports pin them into this package's run requirements;
+        # otherwise downstream C++ consumers (and the cmake-package-check test)
+        # fail to link with undefined onnx::/google::protobuf:: symbols.
+        - libonnx        # [unix]
+        - libprotobuf    # [unix]
+        - libabseil      # [unix]
+        - re2            # [unix]
       run:
         - __cuda    # [cuda_compiler_version != "None"]
       run_constrained:

--- a/recipe/patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch
+++ b/recipe/patches/0006-Use-the-conda-forge-libcoremltools-package-for-the-C.patch
@@ -1,0 +1,69 @@
+From d78bc27058f8fd0342841f33858eb9debc53b544 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sat, 16 May 2026 21:18:40 -0400
+Subject: [PATCH] Use the conda-forge libcoremltools package for the CoreML EP
+
+Instead of vendoring and rebuilding the coremltools sources via
+FetchContent, locate the installed libcoremltools shared library and
+its headers/.proto definitions, and link the library. The CoreML EP
+still compiles coreml_proto itself from the installed .proto files.
+---
+ .../external/onnxruntime_external_deps.cmake  | 25 ++++++++++++-------
+ cmake/onnxruntime_providers_coreml.cmake      |  5 ++++
+ 2 files changed, 21 insertions(+), 9 deletions(-)
+
+diff --git a/cmake/external/onnxruntime_external_deps.cmake b/cmake/external/onnxruntime_external_deps.cmake
+index be0abc9..8f12b26 100644
+--- a/cmake/external/onnxruntime_external_deps.cmake
++++ b/cmake/external/onnxruntime_external_deps.cmake
+@@ -863,15 +863,22 @@ if(onnxruntime_USE_COREML)
+   set(FP16_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
+   onnxruntime_fetchcontent_makeavailable(fp16)
+ 
+-  onnxruntime_fetchcontent_declare(
+-    coremltools
+-    URL ${DEP_URL_coremltools}
+-    URL_HASH SHA1=${DEP_SHA1_coremltools}
+-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/coremltools/crossplatformbuild.patch
+-    EXCLUDE_FROM_ALL
+-  )
+-  # we don't build directly so use Populate. selected files are built from onnxruntime_providers_coreml.cmake
+-  FetchContent_Populate(coremltools)
++  # coremltools is provided by the conda-forge libcoremltools package: its
++  # mlmodel C++ core (MILBlob + modelpackage) built as a shared library, plus
++  # the development headers and the CoreML .proto definitions. Locate that
++  # instead of vendoring and rebuilding the coremltools sources.
++  #
++  # coremltools_SOURCE_DIR is pointed at the installed include tree so that
++  # the ${coremltools_SOURCE_DIR}/... references in
++  # onnxruntime_providers_coreml.cmake (the .proto root and the header
++  # include directories) keep resolving.
++  find_library(coremltools_LIBRARY NAMES coremltools REQUIRED)
++  find_path(coremltools_SOURCE_DIR
++            NAMES mlmodel/format/Model.proto
++            PATH_SUFFIXES coremltools
++            REQUIRED)
++  message(STATUS "Using coremltools library ${coremltools_LIBRARY}")
++  message(STATUS "Using coremltools headers ${coremltools_SOURCE_DIR}")
+ 
+ endif()
+ 
+diff --git a/cmake/onnxruntime_providers_coreml.cmake b/cmake/onnxruntime_providers_coreml.cmake
+index 757198f..b99af7b 100644
+--- a/cmake/onnxruntime_providers_coreml.cmake
++++ b/cmake/onnxruntime_providers_coreml.cmake
+@@ -179,6 +179,11 @@ onnxruntime_add_include_to_target(onnxruntime_providers_coreml coreml_proto)
+ target_link_libraries(onnxruntime_providers_coreml PRIVATE coreml_proto)
+ add_dependencies(onnxruntime_providers_coreml coreml_proto)
+ 
++# The MILBlob and modelpackage helpers are not compiled from source above
++# (coremltools_srcs only matches the installed headers); link the prebuilt
++# coremltools shared library from the conda-forge libcoremltools package.
++target_link_libraries(onnxruntime_providers_coreml PRIVATE ${coremltools_LIBRARY})
++
+ if (APPLE)
+   target_compile_definitions(onnxruntime_providers_coreml PRIVATE __APPLE__)
+ endif()
+-- 
+2.53.0
+

--- a/recipe/patches/0007-Use-the-conda-forge-libabseil-package.patch
+++ b/recipe/patches/0007-Use-the-conda-forge-libabseil-package.patch
@@ -1,0 +1,38 @@
+From 8be63c5013324afa8117d2ad21509bd99f339fc3 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sat, 16 May 2026 23:00:00 -0400
+Subject: [PATCH] Use the conda-forge libabseil package
+
+onnxruntime declares abseil with FIND_PACKAGE_ARGS that include an
+explicit version floor (20250814). Abseil's installed CMake config is
+generated with COMPATIBILITY ExactVersion, so find_package(absl <ver>)
+only succeeds when <ver> matches the installed release *exactly*; any
+other value forces FetchContent to download and statically build a
+vendored abseil.
+
+Drop the version from FIND_PACKAGE_ARGS so the conda-forge libabseil
+package is used. The abseil version is governed by conda-forge pinning
+and is kept consistent with libprotobuf, which hard-depends on a
+specific libabseil release.
+---
+ cmake/external/abseil-cpp.cmake | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/external/abseil-cpp.cmake b/cmake/external/abseil-cpp.cmake
+index a8e925c..fef5ce9 100644
+--- a/cmake/external/abseil-cpp.cmake
++++ b/cmake/external/abseil-cpp.cmake
+@@ -37,7 +37,12 @@ onnxruntime_fetchcontent_declare(
+     URL_HASH SHA1=${DEP_SHA1_abseil_cpp}
+     EXCLUDE_FROM_ALL
+     PATCH_COMMAND ${ABSL_PATCH_COMMAND}
+-    FIND_PACKAGE_ARGS 20250814 NAMES absl
++    # conda-forge: drop the explicit 20250814 version floor. Abseil's installed
++    # CMake config uses COMPATIBILITY ExactVersion, so a version constraint here
++    # only matches that exact release and otherwise forces a vendored build.
++    # The abseil version is instead governed by conda-forge pinning (and kept
++    # consistent with libprotobuf, which hard-depends on a specific libabseil).
++    FIND_PACKAGE_ARGS NAMES absl
+ )
+ 
+ onnxruntime_fetchcontent_makeavailable(abseil_cpp)

--- a/recipe/patches/0008-Skip-ONNX-schema-registration-when-static.patch
+++ b/recipe/patches/0008-Skip-ONNX-schema-registration-when-static.patch
@@ -1,0 +1,52 @@
+From 5da16e2834e3093ecfcc41be8899b5a4eaae0c3d Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sun, 17 May 2026 05:00:00 -0400
+Subject: [PATCH] Skip ONNX schema registration when onnx registers it
+ statically
+
+When onnxruntime is built against an external (find_package) onnx, that
+onnx is normally built with static operator-schema registration enabled
+and registers the ai.onnx, ai.onnx.ml and ai.onnx.training opsets itself
+at library load time. onnxruntime then called RegisterOnnxOperatorSetSchema()
+and friends unconditionally, causing duplicate-schema registration errors.
+
+Guard those calls with ONNX's IsOnnxStaticRegistrationDisabled(). The
+vendored onnx is built with __ONNX_DISABLE_STATIC_REGISTRATION (so the
+function returns true and registration still happens), so this works for
+both the vendored and the unvendored onnx.
+---
+ onnxruntime/core/session/environment.cc | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/onnxruntime/core/session/environment.cc b/onnxruntime/core/session/environment.cc
+index 503aedb..cf25847 100644
+--- a/onnxruntime/core/session/environment.cc
++++ b/onnxruntime/core/session/environment.cc
+@@ -304,15 +304,24 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
+ #ifdef USE_DML
+       dml::RegisterDmlSchemas();
+ #endif
+-      RegisterOnnxOperatorSetSchema();
++      // An unvendored (find_package) onnx is normally built with static
++      // schema registration enabled, in which case it registers the
++      // ai.onnx{,.ml,.training} opsets itself at library load time.
++      // Registering them again here would throw a duplicate-schema error.
++      // onnxruntime's own vendored onnx is built with
++      // __ONNX_DISABLE_STATIC_REGISTRATION, so this guard keeps both the
++      // vendored and the find_package() onnx working.
++      if (ONNX_NAMESPACE::IsOnnxStaticRegistrationDisabled()) {
++        RegisterOnnxOperatorSetSchema();
+ 
+ #ifndef DISABLE_ML_OPS
+-      RegisterOnnxMLOperatorSetSchema();
++        RegisterOnnxMLOperatorSetSchema();
+ #endif
+ 
+ #if defined(ENABLE_TRAINING_OPS)
+-      RegisterOnnxTrainingOperatorSetSchema();
++        RegisterOnnxTrainingOperatorSetSchema();
+ #endif
++      }
+ 
+ #if defined(ENABLE_TRAINING_OPS)
+       // preserve this order until <training schemas>: this depends on operatorsetschema registration.

--- a/recipe/test_onnxruntime_inference.py
+++ b/recipe/test_onnxruntime_inference.py
@@ -1,0 +1,55 @@
+"""Runtime smoke test for the onnxruntime conda package.
+
+This exercises the parts that the unvendored build most needs to get right:
+
+* ``onnx`` and ``onnxruntime`` are imported into the *same* process. With the
+  unvendored libonnx, onnxruntime links the shared ``libonnx`` and relies on
+  ONNX's own static schema registration (recipe patch 0008). If that wiring is
+  wrong this import pair aborts with duplicate ONNX schema / protobuf
+  descriptor-pool registration errors before a single op runs.
+* A tiny model built with ``onnx`` is executed by onnxruntime on the
+  ``CPUExecutionProvider`` -- available on every CI runner -- and the result is
+  checked against numpy. This proves the linked libonnx can actually parse a
+  model and that inference works end to end.
+"""
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import TensorProto, helper
+
+print("onnx", onnx.__version__, "/ onnxruntime", ort.__version__)
+print("providers:", ort.get_available_providers())
+assert "CPUExecutionProvider" in ort.get_available_providers()
+
+# y = relu(a @ b) + c -- a couple of standard ops across a small graph.
+a = helper.make_tensor_value_info("a", TensorProto.FLOAT, [2, 3])
+b = helper.make_tensor_value_info("b", TensorProto.FLOAT, [3, 4])
+c = helper.make_tensor_value_info("c", TensorProto.FLOAT, [2, 4])
+y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 4])
+graph = helper.make_graph(
+    [
+        helper.make_node("MatMul", ["a", "b"], ["ab"]),
+        helper.make_node("Relu", ["ab"], ["r"]),
+        helper.make_node("Add", ["r", "c"], ["y"]),
+    ],
+    "matmul_relu_add",
+    [a, b, c],
+    [y],
+)
+model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 21)])
+onnx.checker.check_model(model)
+
+sess = ort.InferenceSession(
+    model.SerializeToString(), providers=["CPUExecutionProvider"]
+)
+assert sess.get_providers() == ["CPUExecutionProvider"], sess.get_providers()
+
+na = np.random.rand(2, 3).astype(np.float32)
+nb = np.random.rand(3, 4).astype(np.float32)
+nc = np.random.rand(2, 4).astype(np.float32)
+(out,) = sess.run(["y"], {"a": na, "b": nb, "c": nc})
+
+expected = np.maximum(na @ nb, 0.0) + nc
+np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-5)
+print("onnxruntime CPU inference OK, output shape", out.shape)


### PR DESCRIPTION
I've been wanting to help unvendor lots of the stuff that this repo depends on.

The list is:

* libprotobuf
* libabseil
* libonnx
   * https://github.com/conda-forge/onnx-feedstock/pull/146
   * https://github.com/conda-forge/admin-requests/pull/2087
* libcoremltools (only for OSX)
   * https://github.com/conda-forge/coremltools-feedstock/pull/35
   * https://github.com/conda-forge/admin-requests/pull/2088
* re2
* flatbuffers

I'm not really sure how valuable this is, but it is in the spirit of conda-forge as a whole.

So i figured I would ask my AI tools to do the hardest parts of my OSS contributions. 

- [ ] I have reviewed AI's code
- [ ] This code is ready to be read by other humans.

<details><summary>AI's details</summary>

## Draft — not ready to merge

This branch unvendors several of the C++ dependencies that onnxruntime
bundles and builds from source, so the feedstock instead links the
conda-forge shared libraries.

**Blocked on:** `libcoremltools` and `libonnx` are not yet on conda-forge —
they currently live on the experimental `mark.harfouche` channel, which
`recipe/conda_build_config.yaml` adds to `channel_sources` temporarily. CI
on this PR will fail until those packages are published to conda-forge
proper. Opening as a draft to share the approach and gather feedback.

## What this does

onnxruntime 1.26.0 FetchContent-builds and statically links its own copies
of many dependencies. This branch makes it use the conda-forge packages:

| Dependency | Change |
|---|---|
| **libprotobuf** | host dep; `find_package` already supported — no patch |
| **libabseil** | host dep + patch `0007` (onnxruntime pins an exact-version `FIND_PACKAGE_ARGS`; abseil's CMake config is `ExactVersion`, so the constraint must be dropped) |
| **libcoremltools** | patch `0006` — CoreML EP links the prebuilt library instead of vendoring the coremltools sources |
| **libonnx** | host dep + patch `0008`; requires `onnxruntime_USE_FULL_PROTOBUF=ON` (the conda onnx is full-protobuf). The patch guards onnxruntime's schema registration with ONNX's `IsOnnxStaticRegistrationDisabled()` so an externally-linked onnx that statically registers schemas does not double-register |
| **re2** | host dep; `find_package` already supported — no patch |
| **flatbuffers** | build + host dep; `build.sh` regenerates the schema headers with the conda `flatc` (the committed `*.fbs.h` carry a `static_assert` pinning the flatbuffers version) |

Because `onnxruntime_USE_FULL_PROTOBUF=ON` is now set, the compiled C++ unit
tests are skipped — they need ONNX's `.proto` sources, which the `libonnx`
package does not ship. The recipe's own test section (Python import, CoreML
provider, the C++ consumer test, `cmake-package-check`) still runs.

## Still vendored

`cpuinfo` (pytorch/cpuinfo) and `kleidiai` remain vendored and statically
linked — there is no conda-forge package for either yet.

## Known limitations

- The conda-forge `libonnx` does not carry onnxruntime's vendored patch that
  un-deprecates the opset-18 `GroupNormalization` operator, so models with an
  `ai.onnx` `GroupNormalization` node at opset 18–20 are rejected. opset ≥ 21
  is fine. In practice no mainstream exporter emits that operator (they
  decompose group norm), so the impact is minimal.
- Only **osx-arm64** has been build-verified locally (a full conda-build:
  both outputs build, link the conda shared libraries, and pass their
  tests). linux and win are unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
